### PR TITLE
Missed COINBASE_MATURITY value.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -53,7 +53,7 @@ static const int64 DUST_HARD_LIMIT = 10000;   // 0.0001 WDC mininput
 static const int64 MAX_MONEY = 280000000 * COIN;
 inline bool MoneyRange(int64 nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
-static const int COINBASE_MATURITY = 100;
+static const int COINBASE_MATURITY = 70;
 /** Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp. */
 static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
 /** Maximum number of script-checking threads allowed */


### PR DESCRIPTION
COINBASE_MATURITY is 70, not 100.  100 is the LTC value.
