### PR TITLE
Auto Checkpointing Performance Improvements

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -328,6 +328,7 @@ std::string HelpMessage()
         "  -externalip=<ip>       " + _("Specify your own public address") + "\n" +
         "  -onlynet=<net>         " + _("Only connect to nodes in network <net> (IPv4, IPv6 or Tor)") + "\n" +
         "  -discover              " + _("Discover own IP address (default: 1 when listening and no -externalip)") + "\n" +
+        "  -checkpointenforce     " + _("Only accept block chain matching checkpoints issued by the Auto-Checkpoint systems Master Node (default: 1)") + "\n" +
         "  -checkpoints           " + _("Only accept block chain matching built-in checkpoints (default: 1)") + "\n" +
         "  -listen                " + _("Accept connections from outside (default: 1 if no -proxy or -connect)") + "\n" +
         "  -bind=<addr>           " + _("Bind to given address and always listen on it. Use [host]:port notation for IPv6") + "\n" +

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2238,6 +2238,7 @@ bool CBlock::AcceptBlock(CValidationState &state, CDiskBlockPos *dbp)
 
 		// Check that the block satisfies synchronized checkpoint
         if (IsSyncCheckpointEnforced() // checkpoint enforce mode
+            && !IsInitialBlockDownload()  // dont enforce checkpoints while blockchain is being downloaded for the first time
             && !CheckSyncCheckpoint(hash, pindexPrev))
             return error("AcceptBlock() : rejected by synchronized checkpoint");
 


### PR DESCRIPTION
Disables auto-checkpoint checking for every block accept while the initial blockchain download is occurring, which will speed up the initial download considerably. Also adds help text for the new command line option, checkpointenforce.
